### PR TITLE
Update parse version to 1.4.2

### DIFF
--- a/src/leiningen/new/parseapp/app/global.json
+++ b/src/leiningen/new/parseapp/app/global.json
@@ -13,6 +13,6 @@
         }
     },
     "global": {
-        "parseVersion": "1.2.7"
+        "parseVersion": "1.4.2"
     }
 }


### PR DESCRIPTION
For 1.2.7 version there is no some useful method of Parse.Object

For example these don't work:
- fetchAll
- deleteAll
